### PR TITLE
adds sudo option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 | --- | --- | --- | --- |
 | `file_name` | The name (or path) of the text file to generate. | required | `generated_text_file.txt` |
 | `file_content` | Add content for the text file here. You can also use all ENV variables. | required |  |
+| `use_sudo` | The Step always tries a normal (non-sudo) write first, so the generated file stays owned by the current user whenever possible.  If set to `"yes"` and that normal write fails, the Step retries with `sudo`. This is required to generate a file in a privileged (root-owned) location, for example on stacks where the build runs as a non-root user. In that case the generated file will be owned by `root`.  If set to `"no"`, the Step never uses `sudo` and fails if the normal write does not succeed. | required | `yes` |
 </details>
 
 <details>

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -90,9 +90,11 @@ workflows:
         - use_sudo: "no"
         - file_name: ./no-sudo-unprivileged.txt
 
-  # use_sudo=no + privileged (root-owned) location -> expected to FAIL.
-  # The Step is marked is_skippable so the build continues, then we assert
-  # that the file was NOT created.
+  # use_sudo=no + privileged (root-owned) location -> expected to FAIL on
+  # non-root stacks. The Step is marked is_skippable so the build continues,
+  # then we assert that the file was NOT created. On stacks where the build runs
+  # as root the non-sudo write succeeds (root can write anywhere), so the
+  # failure scenario does not apply and the assertion is skipped.
   test_no_sudo_privileged_location_fails:
     steps:
     - path::./:
@@ -112,9 +114,14 @@ workflows:
 
             target="/etc/generate-text-file-e2e-no-sudo-privileged.txt"
 
-            if sudo test -f "$target"; then
+            if [ "$(id -u)" -eq 0 ]; then
+              echo "Running as root; a non-sudo write to a privileged location succeeds on this stack, so the failure scenario does not apply. Skipping assertion."
+              rm -f "$target"
+              exit 0
+            fi
+
+            if [ -f "$target" ]; then
               echo "File should NOT have been created without sudo, but it exists: $target"
-              sudo rm -f "$target"
               exit 1
             fi
 

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -1,23 +1,20 @@
-format_version: "11"
+format_version: "13"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
-workflows:
-  test_generate_text_file:
+step_bundles:
+  # Generates the text file, then verifies the output env var, file existence
+  # and content. When the Step ran with sudo the file is root-owned, so the
+  # verification reads/removes it with sudo too (derived from use_sudo).
+  generate_and_verify:
+    inputs:
+    - use_sudo: ""
+    - file_name: ""
     steps:
-    - change-workdir:
-        title: Switch working dir to _tmp
-        description: |-
-          To prevent step testing issues, like referencing relative
-          files with just './some-file' in the step's code, which would
-          work for testing the step from this directory directly
-          but would break if the step is included in another `bitrise.yml`.
-        inputs:
-        - path: ./_tmp
-        - is_create_path: true
     - path::./:
-        title: Step Test
+        title: Generate text file
         inputs:
-        - file_name: ./test_file.txt
+        - use_sudo: $use_sudo
+        - file_name: $file_name
         - file_content: |
             Example file content,
             multi line!
@@ -28,25 +25,97 @@ workflows:
             #!/bin/bash
             set -e
 
+            # If the Step wrote the file with sudo it is root-owned, so use
+            # sudo to read and remove it as well.
+            sudo=""
+            if [ "$use_sudo" = "yes" ]; then
+              sudo="sudo"
+            fi
+
             if [ -z "$GENERATED_TEXT_FILE_PATH" ]; then
               echo "GENERATED_TEXT_FILE_PATH output is empty"
               exit 1
             fi
 
-            if [ ! -f "$GENERATED_TEXT_FILE_PATH" ]; then
+            if ! $sudo test -f "$GENERATED_TEXT_FILE_PATH"; then
               echo "Generated file does not exist at: $GENERATED_TEXT_FILE_PATH"
               exit 1
             fi
 
             expected=$'Example file content,\nmulti line!'
-            actual="$(cat "$GENERATED_TEXT_FILE_PATH")"
+            actual="$($sudo cat "$GENERATED_TEXT_FILE_PATH")"
             if [ "$actual" != "$expected" ]; then
               echo "Generated file content does not match the expected content."
-              echo "Expected:"
-              echo "$expected"
-              echo "Actual:"
-              echo "$actual"
+              echo "Expected:"; echo "$expected"
+              echo "Actual:"; echo "$actual"
+              $sudo rm -f "$GENERATED_TEXT_FILE_PATH"
               exit 1
             fi
 
             echo "Generated file content matches the expected content."
+            $sudo rm -f "$GENERATED_TEXT_FILE_PATH"
+
+workflows:
+  # use_sudo=yes + privileged (root-owned) location -> succeeds.
+  test_use_sudo_privileged_location:
+    steps:
+    - bundle::generate_and_verify:
+        inputs:
+        - use_sudo: "yes"
+        - file_name: /etc/generate-text-file-e2e-use-sudo-privileged.txt
+
+  # use_sudo=yes + unprivileged location -> succeeds.
+  test_use_sudo_unprivileged_location:
+    steps:
+    - change-workdir:
+        title: Switch working dir to _tmp
+        inputs:
+        - path: ./_tmp
+        - is_create_path: true
+    - bundle::generate_and_verify:
+        inputs:
+        - use_sudo: "yes"
+        - file_name: ./use-sudo-unprivileged.txt
+
+  # use_sudo=no + unprivileged location -> succeeds.
+  test_no_sudo_unprivileged_location:
+    steps:
+    - change-workdir:
+        title: Switch working dir to _tmp
+        inputs:
+        - path: ./_tmp
+        - is_create_path: true
+    - bundle::generate_and_verify:
+        inputs:
+        - use_sudo: "no"
+        - file_name: ./no-sudo-unprivileged.txt
+
+  # use_sudo=no + privileged (root-owned) location -> expected to FAIL.
+  # The Step is marked is_skippable so the build continues, then we assert
+  # that the file was NOT created.
+  test_no_sudo_privileged_location_fails:
+    steps:
+    - path::./:
+        title: Attempt to generate text file without sudo in a privileged location (expected to fail)
+        is_skippable: true
+        inputs:
+        - use_sudo: "no"
+        - file_name: /etc/generate-text-file-e2e-no-sudo-privileged.txt
+        - file_content: |
+            This content should never be written.
+    - script:
+        title: Verify the file was not created
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -e
+
+            target="/etc/generate-text-file-e2e-no-sudo-privileged.txt"
+
+            if sudo test -f "$target"; then
+              echo "File should NOT have been created without sudo, but it exists: $target"
+              sudo rm -f "$target"
+              exit 1
+            fi
+
+            echo "File is correctly absent; the Step failed as expected without sudo."

--- a/main.go
+++ b/main.go
@@ -2,10 +2,14 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/bitrise-io/go-steputils/stepconf"
 	"github.com/bitrise-io/go-steputils/tools"
+	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/fileutil"
 	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-utils/pathutil"
@@ -14,11 +18,57 @@ import (
 type config struct {
 	FileName    string `env:"file_name,required"`
 	FileContent string `env:"file_content,required"`
+	UseSudo     string `env:"use_sudo,opt[yes,no]"`
 }
 
-func fail(format string, v ...interface{}) {
+func fail(format string, v ...any) {
 	log.Errorf(format, v...)
 	os.Exit(1)
+}
+
+// writeFile writes content to path. It always tries as the current user first;
+// if that fails and sudo is enabled, it logs the failure and retries with sudo
+// (required for privileged, root-owned locations on stacks where the build runs
+// as a non-root user). This keeps the generated file user-owned whenever
+// possible and only escalates to root when necessary.
+func writeFile(path, content string, sudoEnabled bool) error {
+	err := fileutil.WriteStringToFile(path, content)
+	if err == nil {
+		return nil
+	}
+	if !sudoEnabled {
+		return err
+	}
+
+	log.Warnf("Failed to write file without sudo: %s", err)
+	log.Printf("Retrying with sudo...")
+
+	return writeFileWithSudo(path, content)
+}
+
+// writeFileWithSudo writes content to path as root, creating parent directories
+// if needed. This is required to generate files in privileged (root-owned)
+// locations on stacks where the build runs as a non-root user. sudo is run with
+// -n (non-interactive) so it fails fast instead of waiting for a password when
+// passwordless sudo is unavailable.
+func writeFileWithSudo(path, content string) error {
+	dir := filepath.Dir(path)
+	mkdir := command.New("sudo", "-n", "mkdir", "-p", dir).
+		SetStdout(os.Stdout).
+		SetStderr(os.Stderr)
+	if err := mkdir.Run(); err != nil {
+		return fmt.Errorf("create parent directory (%s) with sudo: %w", dir, err)
+	}
+
+	tee := command.New("sudo", "-n", "tee", path).
+		SetStdin(strings.NewReader(content)).
+		SetStdout(io.Discard).
+		SetStderr(os.Stderr)
+	if err := tee.Run(); err != nil {
+		return fmt.Errorf("write file with sudo: %w", err)
+	}
+
+	return nil
 }
 
 func main() {
@@ -34,7 +84,7 @@ func main() {
 		fail("Failed to determine absolute path of file (%s): %s", cfg.FileName, err)
 	}
 
-	if err := fileutil.WriteStringToFile(absFilePath, cfg.FileContent); err != nil {
+	if err := writeFile(absFilePath, cfg.FileContent, cfg.UseSudo == "yes"); err != nil {
 		fail("Failed to write into file (%s): %s", absFilePath, err)
 	}
 

--- a/step.yml
+++ b/step.yml
@@ -35,6 +35,25 @@ inputs:
     summary: Add content for the text file here. You can also use all ENV variables.
     is_expand: true
     is_required: true
+- use_sudo: "yes"
+  opts:
+    title: Fall back to sudo
+    summary: Retry the write with `sudo` if a normal write fails.
+    description: |-
+      The Step always tries a normal (non-sudo) write first, so the generated
+      file stays owned by the current user whenever possible.
+
+      If set to `"yes"` and that normal write fails, the Step retries with
+      `sudo`. This is required to generate a file in a privileged (root-owned)
+      location, for example on stacks where the build runs as a non-root user.
+      In that case the generated file will be owned by `root`.
+
+      If set to `"no"`, the Step never uses `sudo` and fails if the normal
+      write does not succeed.
+    is_required: true
+    value_options:
+    - "yes"
+    - "no"
 outputs:
 - GENERATED_TEXT_FILE_PATH:
   opts:


### PR DESCRIPTION
The Linux 26 stack runs as `ubuntu` instead of `root` like previous stacks. THis means that if a user tries to generate a file in a privileged location, the step will succeed on old stacks but fail on the new stack. This PR adds the option to use sudo. 